### PR TITLE
Fixed invalid json in the curl binding example.

### DIFF
--- a/howto/send-events-with-output-bindings/README.md
+++ b/howto/send-events-with-output-bindings/README.md
@@ -37,7 +37,7 @@ All that's left now is to invoke the bindings endpoint on a running Dapr instanc
 We can do so using HTTP:
 
 ```
-curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ data: { "message": "Hi!" } }'
+curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ "data": { "message": "Hi!" } }'
 ```
 
 As seen above, we invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myEvent`.<br>


### PR DESCRIPTION
# Description

The CURL command at the bottom of the document has invalid JSON in the data payload.  The `data` key was not quoted properly, which was returning an error when copy and pasting the command.

## Issue reference

I don't have an issue to reference as I found this problem on my own.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [N/A ] Code compiles correctly
* [N/A] Created/updated tests
* [X] Extended the documentation
